### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/src/local.settings.json
+++ b/src/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "PDFProcessorSTORAGE": "UseDevelopmentStorage=true"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azurite emulator settings for local development. Matches sibling C#/Java/JS/TS blob-eventgrid repos. Storage runs locally via Azurite; Event Grid events can be simulated via VS Code.

## What's included

`src/local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: powershell`
- `PDFProcessorSTORAGE: UseDevelopmentStorage=true`

## Context

Tracked by Azure/azure-functions-templates — ensuring all manifest templates have `local.settings.json` for local development per review feedback on PR #1753.
